### PR TITLE
server: grpc: fix string dereference when printing

### DIFF
--- a/server/grpc_server.go
+++ b/server/grpc_server.go
@@ -219,7 +219,7 @@ func (g grpcServer) PutArtifacts(ctx context.Context, request *proto.PutArtifact
 		nilSafeCopy(&value.State, artifact.State, artifactStateToInt64)
 		// create in DB
 		if err = dbConn.Create(value).Error; err != nil {
-			err = fmt.Errorf("error creating artifact with type_id[%d], name[%s]: %w", value.TypeID, value.Name, err)
+			err = fmt.Errorf("error creating artifact with type_id[%d], name[%s]: %w", value.TypeID, *value.Name, err)
 			return nil, err
 		}
 		// create properties in DB


### PR DESCRIPTION
As `value.Name` is a string pointer it can't be used directly when printing, causing the following build error:

```
server/grpc_server.go:222:10: fmt.Errorf format %s has arg value.Name of wrong type *string
```